### PR TITLE
Refine torch version requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    "torch>=0.4.0+",
+    "torch>=0.4.0",
     "torchvision",
     "numpy",
     "pandas",


### PR DESCRIPTION
## Issue Description
While attempting to install CORnet using Python 3.11.4 and pip 23.1.2 with the command pip install git+https://github.com/dicarlolab/CORnet, an error is thrown during metadata preparation.

## Error Message
```
Collecting git+https://github.com/dicarlolab/CORnet
  Cloning https://github.com/dicarlolab/CORnet to /private/var/folders/5t/glrj0p4s3zl9mxqw4mz04q8m0000gn/T/pip-req-build-it6729e1
  Running command git clone --filter=blob:none --quiet https://github.com/dicarlolab/CORnet /private/var/folders/5t/glrj0p4s3zl9mxqw4mz04q8m0000gn/T/pip-req-build-it6729e1
  Resolved https://github.com/dicarlolab/CORnet to commit 4a0e8e408a45729c8e560d8704761c5172ce3017
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      error in CORnet setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
          torch>=0.4.0+
               ~~~~~~~^
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

## Proposed Fix
The issue can be resolved by removing the + from the torch version specifier in setup.py. After doing this, the package installs without errors.

